### PR TITLE
Resnet50 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ type MNIST = MkINetwork
     ('D1 10)         -- Output
 ```
 
+## How to extend layers definitions
+
+Since this library only implements a subset of features that Keras implement, it's likely that for
+new projects you'll need to add new layers. Due to the modularization of the library, this can be
+done by adding the layer definitions in specific locations of the project:
+
+1. First, add a new auxiliary layer entry for the data type `DLayer` in `TensorSafe.Compile.Expr`.
+   This will make possible the compilation of the layer for all instances of `Generator`. Also, add
+   to the `LayerGenerator` entry for the newly added layer.
+2. Secondly, add the layer definition to the `TensorSafe/Layers` folder. You can copy the
+   definitions from the currently defined layers.
+3. Then, import and expose your layer definition in the `TensorSafe.Layers` module.
+4. Finally, declare how your layer transforms a specific Shape in the `Out` type function.
+
 ## Command line interface
 
 > This interface will change in the near future

--- a/src/TensorSafe/Compile/Expr.hs
+++ b/src/TensorSafe/Compile/Expr.hs
@@ -28,6 +28,7 @@ data DLayer = DActivation
             | DDense
             | DDropout
             | DFlatten
+            | DGlobalAvgPooling2D
             | DInput
             | DLSTM
             | DMaxPooling
@@ -63,6 +64,7 @@ instance LayerGenerator JavaScript where
     generateName _ DDense              = "dense"
     generateName _ DDropout            = "dropout"
     generateName _ DFlatten            = "flatten"
+    generateName _ DGlobalAvgPooling2D = "globalAvgeragePooling2D"
     generateName _ DInput              = "input"
     generateName _ DLSTM               = "lstm"
     generateName _ DMaxPooling         = "maxPooling2d"
@@ -77,6 +79,7 @@ instance LayerGenerator Python where
     generateName _ DDense              = "Dense"
     generateName _ DDropout            = "Dropout"
     generateName _ DFlatten            = "Flatten"
+    generateName _ DGlobalAvgPooling2D = "GlobalAvgeragePooling2D"
     generateName _ DInput              = "Input"
     generateName _ DLSTM               = "LSTM"
     generateName _ DMaxPooling         = "MaxPool2D"

--- a/src/TensorSafe/Compile/Expr.hs
+++ b/src/TensorSafe/Compile/Expr.hs
@@ -21,18 +21,23 @@ import           Text.Casing    (camel, quietSnake)
 -- | Auxiliary data representation of Layers
 -- IMPORTANT: If you add new Layers definitions to `TensorSafe.Layers`, you should add
 -- the corresponding data structure here for the same layer.
-data DLayer = DConv2D
+data DLayer = DActivation
+            | DAdd
+            | DBatchNormalization
+            | DConv2D
             | DDense
             | DDropout
             | DFlatten
+            | DInput
             | DLSTM
             | DMaxPooling
             | DRelu
-            | DActivation
+            | DZeroPadding2D
             deriving Show
 
 -- | Defines the
 data CNetwork = CNSequence CNetwork
+              | CNAdd CNetwork CNetwork
               | CNCons CNetwork CNetwork
               | CNLayer DLayer (Map String String)
               | CNReturn  -- End of initial sequence network
@@ -51,24 +56,32 @@ class LayerGenerator l where
     generateName :: l -> DLayer -> String
 
 instance LayerGenerator JavaScript where
-    generateName _ DConv2D     = "conv2d"
-    generateName _ DDense      = "dense"
-    generateName _ DDropout    = "dropout"
-    generateName _ DFlatten    = "flatten"
-    generateName _ DLSTM       = "lstm"
-    generateName _ DMaxPooling = "maxPooling2d"
-    generateName _ DRelu       = "reLU"
-    generateName _ DActivation = "activation"
+    generateName _ DActivation         = "activation"
+    generateName _ DAdd                = "addStrict"
+    generateName _ DBatchNormalization = "batchNormalization"
+    generateName _ DConv2D             = "conv2d"
+    generateName _ DDense              = "dense"
+    generateName _ DDropout            = "dropout"
+    generateName _ DFlatten            = "flatten"
+    generateName _ DInput              = "input"
+    generateName _ DLSTM               = "lstm"
+    generateName _ DMaxPooling         = "maxPooling2d"
+    generateName _ DRelu               = "reLU"
+    generateName _ DZeroPadding2D      = "zeroPadding2D"
 
 instance LayerGenerator Python where
-    generateName _ DConv2D     = "Conv2D"
-    generateName _ DDense      = "Dense"
-    generateName _ DDropout    = "Dropout"
-    generateName _ DFlatten    = "Flatten"
-    generateName _ DLSTM       = "LSTM"
-    generateName _ DMaxPooling = "MaxPool2D"
-    generateName _ DRelu       = "ReLu"
-    generateName _ DActivation = "Activation"
+    generateName _ DActivation         = "Activation"
+    generateName _ DAdd                = "add"
+    generateName _ DBatchNormalization = "BatchNormalization"
+    generateName _ DConv2D             = "Conv2D"
+    generateName _ DDense              = "Dense"
+    generateName _ DDropout            = "Dropout"
+    generateName _ DFlatten            = "Flatten"
+    generateName _ DInput              = "Input"
+    generateName _ DLSTM               = "LSTM"
+    generateName _ DMaxPooling         = "MaxPool2D"
+    generateName _ DRelu               = "ReLu"
+    generateName _ DZeroPadding2D      = "ZeroPadding2D"
 
 -- | Class that defines which languages are supported for CNetworks generation to text
 class Generator l where

--- a/src/TensorSafe/Examples/ResNet50Example.hs
+++ b/src/TensorSafe/Examples/ResNet50Example.hs
@@ -60,24 +60,24 @@ type ResNet50 img_size channels =
      -- Second block
      , Add (ConvBlock 256 3 1 128 128 512) (Shortcut 256 1 512) , Relu
      , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
-    --  , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
-    --  , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
+     , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
+     , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
 
-     -- Third block
-    --  , Add (ConvBlock 512 3 1 256 256 1024) (Shortcut 512 1 1024) , Relu
-    --  , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
-    --  , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
-    --  , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
-    --  , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
-    --  , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
+    --  Third block
+     , Add (ConvBlock 512 3 1 256 256 1024) (Shortcut 512 1 1024) , Relu
+     , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
+     , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
+     , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
+     , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
+     , Add (IdentityBlock 1024 3 256 256 1024) '[Input] , Relu
 
     --  -- Fourth block
-    --  , Add (ConvBlock 1024 3 1 512 512 2048) (Shortcut 512 1 2048) , Relu
-    --  , Add (IdentityBlock 1024 3 512 512 2048) '[Input] , Relu
-    --  , Add (IdentityBlock 1024 3 512 512 2048) '[Input] , Relu
+     , Add (ConvBlock 1024 3 1 512 512 2048) (Shortcut 1024 1 2048) , Relu
+     , Add (IdentityBlock 2048 3 512 512 2048) '[Input] , Relu
+     , Add (IdentityBlock 2048 3 512 512 2048) '[Input] , Relu
 
      , GlobalAvgPooling2D
-     , Dense 512 1000
+     , Dense 2048 1000
     ]
     ('D3 img_size img_size channels)    -- Input
     ('D1 1000)                            -- Output

--- a/src/TensorSafe/Examples/ResNet50Example.hs
+++ b/src/TensorSafe/Examples/ResNet50Example.hs
@@ -60,8 +60,8 @@ type ResNet50 img_size channels =
      -- Second block
      , Add (ConvBlock 256 3 1 128 128 512) (Shortcut 256 1 512) , Relu
      , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
-     , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
-     , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
+    --  , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
+    --  , Add (IdentityBlock 512 3 128 128 512) '[Input] , Relu
 
      -- Third block
     --  , Add (ConvBlock 512 3 1 256 256 1024) (Shortcut 512 1 1024) , Relu

--- a/src/TensorSafe/Examples/ResNet50Example.hs
+++ b/src/TensorSafe/Examples/ResNet50Example.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+{-| This module implements the ResNet50 model using Convs with BatchNormalization.
+    This implementation is based on the Keras application implementation:
+    https://github.com/keras-team/keras-applications/blob/master/keras_applications/resnet50.py
+-}
+module TensorSafe.Examples.ResNet50Example where
+
+import           TensorSafe.Layers
+import           TensorSafe.Network (MkINetwork, mkINetwork)
+import           TensorSafe.Shape
+
+
+type IdentityBlock inputNetwork axis kernel_size filters1 filters2 filters3 i o =
+    MkINetwork
+    '[
+        Conv2D 1 filters1 1 1 1 1,
+        BatchNormalization axis 99 1,
+        Relu,
+        Conv2D 1 filters2 kernel_size kernel_size 1 1,
+        BatchNormalization axis 99 1,
+        Relu,
+        Conv2D 1 filters3 1 1 1 1,
+        BatchNormalization axis 99 1,
+        Relu,
+        Add inputNetwork,
+        Relu
+    ]
+    i    -- Input
+    o    -- Output
+
+
+type Shortcut axis channels filters3 stride_size i o =
+    MkINetwork
+    '[
+        Conv2D channels filters3 1 1 stride_size stride_size,
+        BatchNormalization axis 99 1
+    ]
+    i    -- Input
+    o    -- Output
+
+
+type ConvBlock shortcut axis channels kernel_size stride_size filters1 filters2 filters3 i o =
+    MkINetwork
+    '[
+        Conv2D channels filters1 1 1 stride_size stride_size,
+        BatchNormalization axis 99 1,
+        Relu,
+        Conv2D filters1 filters2 kernel_size kernel_size 1 1,
+        BatchNormalization axis 99 1,
+        Relu,
+        Conv2D filters2 filters3 1 1 1 1,
+        BatchNormalization axis 99 1,
+        Relu,
+        Add shortcut,
+        Relu
+    ]
+    i    -- Input
+    o
+type ResNet50 axis img_size channels =
+    MkINetwork
+    '[ Input
+     , ZeroPadding2D 3 3
+     , Conv2D channels 64 7 7 2 2
+     , BatchNormalization axis 99 1
+     , Relu
+     , ZeroPadding2D 1 1
+     , MaxPooling 3 3 2 2
+    --  conv_block(x, 3, [64, 64, 256], stage=2, block='a', strides=(1, 1))
+    -- ConvBlock shortcut axis kernel_size stride_size filters1 filters2 filters3 =
+     , ConvBlock
+        (Shortcut axis 64 256 1 ('D3 54 54 64) ('D3 54 54 256))
+        axis
+        64
+        3
+        1
+        64
+        64
+        256
+        ('D3 56 56 64)
+        ('D3 54 54 256)
+    ]
+    ('D3 img_size img_size channels)    -- Input
+    ('D1 10)       -- Output
+
+resnet50 :: ResNet50 3 224 1
+resnet50 = mkINetwork

--- a/src/TensorSafe/Layers.hs
+++ b/src/TensorSafe/Layers.hs
@@ -6,6 +6,7 @@ module TensorSafe.Layers (
     Dense,
     Dropout,
     Flatten,
+    GlobalAvgPooling2D,
     Input,
     LSTM,
     MaxPooling,
@@ -20,6 +21,7 @@ import           TensorSafe.Layers.Conv2D
 import           TensorSafe.Layers.Dense
 import           TensorSafe.Layers.Dropout
 import           TensorSafe.Layers.Flatten
+import           TensorSafe.Layers.GlobalAvgPooling2D
 import           TensorSafe.Layers.Input
 import           TensorSafe.Layers.LSTM
 import           TensorSafe.Layers.MaxPooling

--- a/src/TensorSafe/Layers.hs
+++ b/src/TensorSafe/Layers.hs
@@ -1,20 +1,28 @@
 {-| This module exposes all Layers declared at TensorSafe.Layers. -}
 module TensorSafe.Layers (
+    Add,
+    BatchNormalization,
     Conv2D,
     Dense,
     Dropout,
     Flatten,
+    Input,
     LSTM,
     MaxPooling,
     Relu,
-    Sigmoid
+    Sigmoid,
+    ZeroPadding2D
 ) where
 
+import           TensorSafe.Layers.Add
+import           TensorSafe.Layers.BatchNormalization
 import           TensorSafe.Layers.Conv2D
 import           TensorSafe.Layers.Dense
 import           TensorSafe.Layers.Dropout
 import           TensorSafe.Layers.Flatten
+import           TensorSafe.Layers.Input
 import           TensorSafe.Layers.LSTM
 import           TensorSafe.Layers.MaxPooling
 import           TensorSafe.Layers.Relu
 import           TensorSafe.Layers.Sigmoid
+import           TensorSafe.Layers.ZeroPadding2D

--- a/src/TensorSafe/Layers/Add.hs
+++ b/src/TensorSafe/Layers/Add.hs
@@ -11,10 +11,11 @@ import           TensorSafe.Compile.Expr
 import           TensorSafe.Layer
 
 -- | Adds the dimensions of the shapes to a list of values with shape D1
-data Add :: layer -> Type where
-    Add :: Add layer
+data Add :: ls1 -> ls2 -> Type where
+    Add :: Add ls1 ls2
     deriving Show
 
-instance (Layer layer) => Layer (Add layer) where
+-- instance (Layer l1, Layer l2) => Layer (Add l1 l2) where
+instance Layer (Add ls1 ls2) where
     layer = Add
     compile _ _ = CNLayer DAdd empty

--- a/src/TensorSafe/Layers/Add.hs
+++ b/src/TensorSafe/Layers/Add.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+{-# LANGUAGE PolyKinds #-}
+{-| This module declares the Add layer data type. -}
+module TensorSafe.Layers.Add (Add) where
+
+import           Data.Kind               (Type)
+import           Data.Map
+
+import           TensorSafe.Compile.Expr
+import           TensorSafe.Layer
+
+-- | Adds the dimensions of the shapes to a list of values with shape D1
+data Add :: layer -> Type where
+    Add :: Add layer
+    deriving Show
+
+instance (Layer layer) => Layer (Add layer) where
+    layer = Add
+    compile _ _ = CNLayer DAdd empty

--- a/src/TensorSafe/Layers/BatchNormalization.hs
+++ b/src/TensorSafe/Layers/BatchNormalization.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-| This module declares the BatchNormalization layer data type. -}
+module TensorSafe.Layers.BatchNormalization where
+
+import           Data.Kind               (Type)
+import           Data.Map
+import           Data.Proxy
+import           GHC.TypeLits
+
+import           TensorSafe.Compile.Expr
+import           TensorSafe.Layer
+
+
+-- | A classic BatchNormalization layer with axis, momentum and epsilon parameters
+data BatchNormalization :: Nat -> Nat -> Nat -> Type where
+    BatchNormalization :: BatchNormalization axis momentum epsilon
+    deriving Show
+
+instance ( KnownNat axis
+         , KnownNat momentum
+         , KnownNat epsilon
+         ) => Layer (BatchNormalization axis momentum epsilon) where
+    layer = BatchNormalization
+    compile _ _ =
+        let axis = show $ natVal (Proxy :: Proxy axis)
+            momentum = show $ natVal (Proxy :: Proxy momentum)
+            epsilon = show $ natVal (Proxy :: Proxy epsilon)
+        in
+            CNLayer DBatchNormalization (fromList [
+              ("axis", axis),
+              ("epsilon", epsilon),
+              ("momentum", momentum)
+            ])

--- a/src/TensorSafe/Layers/GlobalAvgPooling2D.hs
+++ b/src/TensorSafe/Layers/GlobalAvgPooling2D.hs
@@ -1,0 +1,15 @@
+{-| This module declares the GlobalAvgPooling2D layer data type. -}
+module TensorSafe.Layers.GlobalAvgPooling2D (GlobalAvgPooling2D) where
+
+import           Data.Map
+
+import           TensorSafe.Compile.Expr
+import           TensorSafe.Layer
+
+-- | A GlobalAvgPooling2D function
+data GlobalAvgPooling2D = GlobalAvgPooling2D deriving Show
+
+instance Layer GlobalAvgPooling2D where
+    layer = GlobalAvgPooling2D
+    compile _ _ = CNLayer DGlobalAvgPooling2D empty
+

--- a/src/TensorSafe/Layers/Input.hs
+++ b/src/TensorSafe/Layers/Input.hs
@@ -1,0 +1,19 @@
+{-| This module declares the Input layer data type. -}
+module TensorSafe.Layers.Input (Input) where
+
+import           Data.Map
+
+import           TensorSafe.Compile.Expr
+import           TensorSafe.Layer
+
+-- | Inputs the dimensions of the shapes to a list of values with shape D1
+data Input = Input deriving Show
+
+instance Layer Input where
+    layer = Input
+    compile _ inputShape =
+        let params = case inputShape of
+                        Just shape -> fromList [("inputShape", shape)]
+                        Nothing    -> empty
+        in
+            CNLayer DInput params

--- a/src/TensorSafe/Layers/ZeroPadding2D.hs
+++ b/src/TensorSafe/Layers/ZeroPadding2D.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-| This module declares the ZeroPadding2D layer data type. -}
+module TensorSafe.Layers.ZeroPadding2D (ZeroPadding2D) where
+
+import           Data.Kind               (Type)
+import           Data.Map
+import           Data.Proxy
+import           GHC.TypeLits
+
+import           TensorSafe.Compile.Expr
+import           TensorSafe.Layer
+
+-- | A ZeroPadding2D layer with padding_rows and padding_cols arguments
+data ZeroPadding2D :: Nat -> Nat -> Type where
+    ZeroPadding2D :: ZeroPadding2D padding_rows padding_cols
+    deriving Show
+
+instance ( KnownNat padding_rows
+         , KnownNat padding_cols
+         ) => Layer (ZeroPadding2D padding_rows padding_cols) where
+    layer = ZeroPadding2D
+    compile _ _ =
+        let padding_rows = show $ natVal (Proxy :: Proxy padding_rows)
+            padding_cols = show $ natVal (Proxy :: Proxy padding_cols)
+        in
+            CNLayer DZeroPadding2D (fromList [
+                ("padding_rows", padding_rows),
+                ("padding_cols", padding_cols)
+            ])

--- a/src/TensorSafe/Network.hs
+++ b/src/TensorSafe/Network.hs
@@ -133,6 +133,10 @@ type family MaybeShape (s :: Shape) (b :: Bool) :: Shape where
     MaybeType s 'False = 'D1 0 -- HACK: ShapeEquals' should raise an exception on this case
     MaybeType s 'True  = s
 
+
+type family Add' (layers :: [Type]) (layers2 :: [Type]) (shape :: Shape) where
+    Add' ls1 _ sIn = ComputeOut ls1 sIn
+
 -- | Defines the expected output of a layer
 --   This type function should be instanciated for each of the Layers defined.
 type family Out (l :: Type) (s :: Shape) :: Shape where
@@ -144,10 +148,10 @@ type family Out (l :: Type) (s :: Shape) :: Shape where
     --
     --
     --
-    Out (Add ls1 ls2) sIn =
-        MaybeShape
-            (ComputeOut ls1 sIn)
-            (ShapeEquals' (ComputeOut ls1 sIn) (ComputeOut ls2 sIn))  -- Validation that computes the same
+    Out (Add ls1 ls2) sIn = Add' ls1 ls2 sIn
+        -- MaybeShape
+        --     (ComputeOut ls1 sIn)
+        --     (ShapeEquals' (ComputeOut ls1 sIn) (ComputeOut ls2 sIn))  -- Validation that computes the same
     -- Out (Add (INetwork ls (s : ss))) s = ComputeOut ls s
 
     --

--- a/src/TensorSafe/Network.hs
+++ b/src/TensorSafe/Network.hs
@@ -139,6 +139,17 @@ type family Out (l :: Type) (s :: Shape) :: Shape where
     --
     --
     --
+    Out (Add _) s = s
+    -- Out (Add (INetwork ls (s : ss))) s = ComputeOut ls s
+
+    --
+    --
+    --
+    Out (BatchNormalization _ _ _) s = s
+
+    --
+    --
+    --
     Out (Conv2D 1 1 k k' s s') ('D2 inputRows inputColumns) =
         ('D2 (1 + (Div (inputRows - k) s))
                 (1 + (Div (inputColumns - k') s'))
@@ -181,6 +192,11 @@ type family Out (l :: Type) (s :: Shape) :: Shape where
     --
     --
     --
+    Out Input s = s
+
+    --
+    --
+    --
     Out (LSTM units 'False) _           = 'D1 units
     Out (LSTM units 'True)  ('D2 x _)   = 'D2 x units
     Out (LSTM units 'True)  ('D3 x _ _) = 'D2 x units
@@ -202,21 +218,30 @@ type family Out (l :: Type) (s :: Shape) :: Shape where
     --
     --
     --
-    Out Relu s           = s
+    Out Relu s = s
 
     --
     --
     --
-    Out Sigmoid s           = s
+    Out Sigmoid s = s
+
+    --
+    --
+    --
+    Out (ZeroPadding2D padding_rows padding_cols) ('D2 inputRows inputColumns) =
+        ('D2 (inputRows + (2 N.* padding_rows)) (inputColumns + (2 N.* padding_cols)))
+
+    Out (ZeroPadding2D padding_rows padding_cols) ('D3 inputRows inputColumns channels) =
+        ('D3 (inputRows + (2 N.* padding_rows)) (inputColumns + (2 N.* padding_cols)) channels)
 
     --
     -- Edge case or not defined raise an error
     --
-    Out l sOut =
+    Out l sIn =
         TypeError ( 'Text "Couldn't apply the Layer \""
                 ':<>: 'ShowType l
-                ':<>: 'Text "\" with the output Shape \""
-                ':<>: 'ShowType sOut
+                ':<>: 'Text "\" with the input Shape \""
+                ':<>: 'ShowType sIn
                 ':<>: 'Text "\"")
 
 --


### PR DESCRIPTION
This fixes #12 

Implementation of ResNet50 involved adding some new layers:

* `Add`
* `BatchNormalization`
* `GlobalAvgPooling2D`
* `ZeroPadding2D`

Layer checking for these networks are currently working. However, there are still pending some changes to make compilation of residual networks possible. This will be done in a future PR.